### PR TITLE
Add ament_lint_auto dependency to package.xml.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>tf2_ros</exec_depend>
   <depend>ament_cmake_auto</depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
   <test_depend>ouxt_lint_common</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
There is a CMake dependency in this package which is not being declared in the package.xml, thus this package has not yet built succesfully on the [ROS 2 build farm](https://build.ros2.org/job/Rbin_uF64__quaternion_operation__ubuntu_focal_amd64__binary/). 

Below is an excerpt from the build log for the [most recent AMD64 build](https://build.ros2.org/job/Rbin_uF64__quaternion_operation__ubuntu_focal_amd64__binary/22/).

```
CMake Error at CMakeLists.txt:57 (find_package):
  By not providing "Findament_lint_auto.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ament_lint_auto", but CMake did not find one.

  Could not find a package configuration file provided by "ament_lint_auto"
  with any of the following names:

    ament_lint_autoConfig.cmake
    ament_lint_auto-config.cmake

  Add the installation prefix of "ament_lint_auto" to CMAKE_PREFIX_PATH or
  set "ament_lint_auto_DIR" to a directory containing one of the above files.
  If "ament_lint_auto" provides a separate development package or SDK, be
  sure it has been installed.


-- Configuring incomplete, errors occurred!
```
